### PR TITLE
12 dynamic proxy

### DIFF
--- a/example.server.js
+++ b/example.server.js
@@ -37,28 +37,28 @@ bs.create({
     plugins: [],
 }).subscribe(bs => {
     console.log(bs.options.get('urls'));
-    // console.log(bs.options.get('plugins').toJS());
+    bs.setOption('clientJs', function (cjs) {
+        return cjs.concat('console.log("shane")');
+    }).subscribe();
 
-    setTimeout(function () {
-        console.log('resetting');
-        bs.setOption('proxy', function (proxies) {
-            return {
-                target: 'http://wearejh.com',
-                id: 'MY TING',
-                route: "/api"
-            };
-        }).subscribe();
-    }, 2000);
-
-    setTimeout(function () {
-        console.log('resetting');
-        bs.setOption('proxy', function (proxies) {
-            return {
-                target: 'http://wearejh.com',
-                id: 'MY TING',
-                route: "/api"
-            };
-        }).subscribe();
-    }, 3000);
+    // setTimeout(function () {
+    //     bs.setOption('proxy', function (proxies) {
+    //         return {
+    //             target: 'http://wearejh.com',
+    //             id: 'MY TING',
+    //             route: "/api"
+    //         };
+    //     }).subscribe();
+    // }, 2000);
+    //
+    // setTimeout(function () {
+    //     bs.setOption('proxy', function (proxies) {
+    //         return proxies.concat({
+    //             target: 'http://m2.wearejh.com',
+    //             id: 'MY TING',
+    //             route: "/api2"
+    //         });
+    //     }).subscribe();
+    // }, 3000);
 });
 

--- a/example.server.js
+++ b/example.server.js
@@ -34,41 +34,31 @@ bs.create({
     proxy: {
        target: 'http://www.bbc.co.uk'
     },
-    //scheme: 'https',
-    //rewriteRules: [
-        //{
-            //match: /info\.sunspel\.dev/g,
-            //fn: function (req, res, match) {
-            //    return 'http://' + req.headers['host'];
-            //}
-        //}
-    //],
-    plugins: [
-        //{
-        //    module: {
-        //        initAsync: function (bs, opts, cb) {
-        //            bs.getWatcher()
-        //        }
-        //    },
-        //    name: 'my plugin',
-        //    options: {
-        //        files: "test/fixtures/*.html"
-        //    }
-        //},
-        //'/Users/shakyshane/Sites/browser-sync-modules/browser-sync-cp', // laptop
-        //'/Users/shakyshane/Sites/browser-sync-modules/browser-sync-cp', // laptop
-        //'./lib/plugins/proxy',
-        //'./lib/plugins/404',
-        // './test/fixtures/plugins/awesome.js'
-        //'/Users/shakyshane/sites/oss/UI'
-    ],
-    //externals: {
-        //clientJs: __dirname + '/client/'
-        //clientJs: '/Users/shakyshane/code/bs-client' // laptop
-        //clientJs: '/Users/shakyshane/sites/oss/browser-sync-client/' // home imac
-    //}
-    //minify: false
+    plugins: [],
 }).subscribe(bs => {
     console.log(bs.options.get('urls'));
     // console.log(bs.options.get('plugins').toJS());
+
+    setTimeout(function () {
+        console.log('resetting');
+        bs.setOption('proxy', function (proxies) {
+            return {
+                target: 'http://wearejh.com',
+                id: 'MY TING',
+                route: "/api"
+            };
+        }).subscribe();
+    }, 2000);
+
+    setTimeout(function () {
+        console.log('resetting');
+        bs.setOption('proxy', function (proxies) {
+            return {
+                target: 'http://wearejh.com',
+                id: 'MY TING',
+                route: "/api"
+            };
+        }).subscribe();
+    }, 3000);
 });
+

--- a/example.server.js
+++ b/example.server.js
@@ -6,12 +6,12 @@ bs.create({
     //     'test/fixtures'
     // ],
     middleware: [
-       {
-           route: "/shane",
-           handle: function (req, res) {
-               return res.end('<html>shane is cool</html>');
-           }
-       }
+        {
+            route: "/shane",
+            handle: function (req, res) {
+                return res.end('<html>shane is cool</html>');
+            }
+        }
     ],
     //watchDebounce: 2000,
     //watchDelay: 2000,
@@ -32,14 +32,29 @@ bs.create({
         //}
     ],
     proxy: {
-       target: 'http://www.bbc.co.uk'
+        target: 'http://www.bbc.co.uk',
+        id: 'Shane Proxy'
     },
-    plugins: [],
+    plugins: []
 }).subscribe(bs => {
+
     console.log(bs.options.get('urls'));
-    bs.setOption('clientJs', function (cjs) {
-        return cjs.concat('console.log("shane")');
+
+    bs.setOption('proxy', function (proxies) {
+        return 'http://wearejh.com';
     }).subscribe();
+
+    setTimeout(function () {
+        bs.setOption('proxy', function (proxies) {
+            return 'http://www.bbc.co.uk';
+        }).subscribe();
+    }, 5000);
+
+    setTimeout(function () {
+        bs.setOption('proxy', function (proxies) {
+            return 'http://wearejh.com';
+        }).subscribe();
+    }, 10000);
 
     // setTimeout(function () {
     //     bs.setOption('proxy', function (proxies) {

--- a/lib/browser-sync.ts
+++ b/lib/browser-sync.ts
@@ -227,7 +227,7 @@ function go(options, observer) {
                 (prev) => {
                     // call an internal function to transform what the user
                     // has provided into the correct internal type
-                    return optionUpdaters[x.selector].call(null, x.fn.call(null, prev.toJS()))
+                    return bs.optionUpdaters[x.selector].call(null, x.fn.call(null, prev.toJS()))
                 }
             );
         })

--- a/lib/browser-sync.ts
+++ b/lib/browser-sync.ts
@@ -222,14 +222,9 @@ function go(options, observer) {
         }
 
         return input.withLatestFrom(optSub, (x, opts) => {
-            return opts.updateIn( // update a current value
-                x.selector.split('.'), // make selector an array always
-                (prev) => {
-                    // call an internal function to transform what the user
-                    // has provided into the correct internal type
-                    return bs.optionUpdaters[x.selector].call(null, x.fn.call(null, prev.toJS()))
-                }
-            );
+            const prev = opts.getIn(x.selector.split('.')).toJS();
+            const modified = x.fn.call(null, prev);
+            return bs.optionUpdaters[x.selector].call(null, modified, opts);
         })
         .do(x => optSub.onNext(x)) // pump new options value into opts subject
         .do(applyMw) // re-apply middleware stack;

--- a/lib/browser-sync.ts
+++ b/lib/browser-sync.ts
@@ -54,6 +54,7 @@ export interface BrowserSync {
     inject: (any) => void
     applyMw: (options: Immutable.Map<any, any>) => void
     watchers?: any
+    optionUpdaters: any
 }
 
 bs.create = function (userOptions) {
@@ -119,13 +120,11 @@ function go(options, observer) {
      * normally occur when setting an option
      * @type {{clientJs: Function, rewriteRules: Function, middleware: Function}}
      */
-    const optionUpdaters = {
+    bs.optionUpdaters = {
         clientJs: clientJs.fromJS,
         middleware: middleware.fromJS,
         rewriteRules: rewriteRules.fromJS
     };
-
-    const updatableOptions = Object.keys(optionUpdaters);
 
     /**
      * Quite servers, remove event listeners, kill timers, stop
@@ -210,7 +209,7 @@ function go(options, observer) {
 
         const input = Rx.Observable.just({selector, fn});
 
-        if (updatableOptions.indexOf(selector) === -1) {
+        if (Object.keys(bs.optionUpdaters).indexOf(selector) === -1) {
             return input
                 .withLatestFrom(optSub, (x, opts) => {
                     return opts.updateIn( // update a current value

--- a/lib/browser-sync.ts
+++ b/lib/browser-sync.ts
@@ -1,5 +1,6 @@
 /// <reference path="../typings/main.d.ts" />
 import {Socket} from "./sockets";
+import Immutable = require("immutable");
 
 'use strict';
 
@@ -51,6 +52,7 @@ export interface BrowserSync {
     getExternalSocketConnector: (opts: any) => string
     reload: () => void
     inject: (any) => void
+    applyMw: (options: Immutable.Map<any, any>) => void
     watchers?: any
 }
 
@@ -282,9 +284,12 @@ function go(options, observer) {
         }
     });
 
+
     function applyMw(options) {
         bsServer.app.stack = middleware.getMiddleware(options).middleware;
     }
+
+    bs.applyMw = applyMw;
 
     /**
      * Resolve all async plugin init/initAsync functions

--- a/lib/client-js.ts
+++ b/lib/client-js.ts
@@ -1,7 +1,5 @@
-const Immutable          = require('immutable');
+import Immutable = require('immutable');
 const clientJs           = exports;
-
-
 const snippet            = require('./snippet');
 const connectUtils       = require('./connect-utils');
 const fs                 = require('fs');
@@ -105,8 +103,7 @@ clientJs.addBuiltIns = function (options) {
                 content: fs.readFileSync(clientJsPath, 'utf8')
             }
         ].map((x: ClientJsOption) => {
-            x.via = 'Browsersync core';
-            return x;
+            return new ClientJs(x);
         })).concat(x);
     });
 };
@@ -186,11 +183,10 @@ ${x.get('content')}
 clientJs.createOne = createOne;
 
 /**
- * @param coll
- * @returns {*}
+ *
  */
-clientJs.fromJS = function (coll) {
-    return Immutable.fromJS(coll.map(x => createOne('inline-plugin', x)));
+clientJs.fromJS = function (modified: ClientJsOption[], options: Immutable.Map<string, any>) {
+    return options.set(OPT_NAME, Immutable.fromJS(modified.map(x => createOne('inline-plugin', x))));
 };
 
 /**

--- a/lib/default-options.ts
+++ b/lib/default-options.ts
@@ -46,7 +46,7 @@ module.exports = <BrowsersyncOptions>{
         whitelist: [],
         blacklist: [],
         rule: {
-            match: /$/,
+            match: /<body[^>]*>/i,
             fn: function (snippet, req, res, match) {
                 return match + snippet;
             }

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -67,9 +67,9 @@ module.exports.createOne = createOne;
 /**
  * JS -> Immutable transformation
  */
-mw.fromJS = function (modified: MiddlewareItem[], options: Immutable.Map<string, any>) {
+export function fromJS(modified: MiddlewareItem[], options: Immutable.Map<string, any>) {
     return options.set(OPT_NAME, Immutable.fromJS(modified.map(createOne)));
-};
+}
 
 /**
  * Combine default + user + plugin middlewares

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -7,6 +7,8 @@ const clientJs     = require('./client-js');
 const respMod      = require('resp-modifier');
 const mergeOpts    = require('./transform-options').mergeOptionsWithPlugins;
 var   count        = 0;
+const OPT_NAME     = 'middleware';
+
 
 export interface MiddlewareItem {
     id: string
@@ -40,7 +42,7 @@ mw.merge = function (options) {
  * @returns {Map}
  */
 mw.decorate = function (options) {
-    return options.update('middleware', x => x.map(createOne));
+    return options.update(OPT_NAME, x => x.map(createOne));
 };
 
 /**
@@ -64,11 +66,9 @@ module.exports.createOne = createOne;
 
 /**
  * JS -> Immutable transformation
- * @param coll
- * @returns {*}
  */
-mw.fromJS = function (coll) {
-    return Immutable.fromJS(coll.map(createOne));
+mw.fromJS = function (modified: MiddlewareItem[], options: Immutable.Map<string, any>) {
+    return options.set(OPT_NAME, Immutable.fromJS(modified.map(createOne)));
 };
 
 /**

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,4 +1,4 @@
-const Immutable    = require('immutable');
+import Immutable = require('immutable');
 const mw           = exports;
 import utils from './utils';
 const isFunction   = utils.isFunction;
@@ -8,13 +8,21 @@ const respMod      = require('resp-modifier');
 const mergeOpts    = require('./transform-options').mergeOptionsWithPlugins;
 var   count        = 0;
 
+export interface MiddlewareItem {
+    id: string
+    route: string
+    handle: () => void
+    via?: string
+}
+
 /**
  * Middleware option schema
  */
-const MiddlewareOption = Immutable.Record({
+const MiddlewareOption = Immutable.Record(<MiddlewareItem>{
     id: '',
     route: '',
-    handle: undefined
+    via: '',
+    handle: () => {}
 });
 
 /**
@@ -83,12 +91,14 @@ mw.getMiddleware = function (options) {
             {
                 route: options.get('scriptPath'),
                 id: 'bs-client',
-                handle: clientJsHandle
+                handle: clientJsHandle,
+                via: 'Browsersync Core'
             },
             {
                 route: '',
                 id: 'bs-rewrite-rules',
-                handle: snippetMw.middleware
+                handle: snippetMw.middleware,
+                via: 'Browsersync Core'
             }
         ]
         .concat(options.get('middleware').toJS())

--- a/lib/plugins/proxy-utils.ts
+++ b/lib/plugins/proxy-utils.ts
@@ -1,12 +1,6 @@
-var url = require('url');
-import NodeURL  = require('url');
-
-export interface RewriteRule {
-    match: string|RegExp
-    fn?: (req:any, res:any, match:string) => string | string
-    replace?: (req:any, res:any, match:string) => string | string
-    via?: string
-}
+import {RewriteRule} from "../rewrite-rules";
+import NodeURL = require('url');
+const url = require('url');
 
 export function rewriteLinks (userServer: NodeURL.Url): RewriteRule {
 

--- a/lib/plugins/proxy-utils.ts
+++ b/lib/plugins/proxy-utils.ts
@@ -1,8 +1,14 @@
 var url = require('url');
 import NodeURL  = require('url');
 
+export interface RewriteRule {
+    match: string|RegExp
+    fn?: (req:any, res:any, match:string) => string | string
+    replace?: (req:any, res:any, match:string) => string | string
+    via?: string
+}
 
-export function rewriteLinks (userServer: NodeURL.Url) {
+export function rewriteLinks (userServer: NodeURL.Url): RewriteRule {
 
     var host   = userServer.hostname;
     var string = host;
@@ -19,7 +25,7 @@ export function rewriteLinks (userServer: NodeURL.Url) {
         //match: new RegExp("https?:\\\\?/\\\\?/" + string + "(\/)?|('|\")(https?://|\\\\?/|\\.)?" + string + "(\/)?(.*?)(?=[ ,'\"\\s])", "g"),
         //match: new RegExp('https?://' + string + '(\/)?|(\'|")(https?://|/|\\.)?' + string + '(\/)?(.*?)(?=[ ,\'"\\s])', 'g'),
         //match: new RegExp("https?:\\\\/\\\\/" + string, "g"),
-        fn:    function (req, res, match) {
+        fn: function (req, res, match) {
 
             var proxyUrl = req.headers['host'];
 

--- a/lib/plugins/proxy.ts
+++ b/lib/plugins/proxy.ts
@@ -8,7 +8,7 @@ import utils from '../utils';
 const isString  = utils.isString;
 
 import * as proxyUtils from './proxy-utils';
-import {RewriteRule} from "./proxy-utils";
+import {RewriteRule} from "../rewrite-rules";
 
 /**
  * Initial options used when creating the node http-proxy server

--- a/lib/plugins/proxy.ts
+++ b/lib/plugins/proxy.ts
@@ -74,6 +74,18 @@ module.exports.init = function (bs, opts, obs) {
     const proxies     = bs.options.getIn([OPT_NAME]);
 
     /**
+     * Listen for option updates to the proxy
+     */
+    bs.options$
+        .distinctUntilChanged(null, function (a, b) {
+            return Imm.is(a.get('proxy'), b.get('proxy'));
+        })
+        .skip(1)
+        .subscribe(x => {
+            // If we reach here then the proxy option has be
+        });
+
+    /**
      * For each proxy given, create a separate http-proxy server
      * middleware in the Browsersync format
      * with the options provided.

--- a/lib/plugins/proxy.ts
+++ b/lib/plugins/proxy.ts
@@ -190,8 +190,9 @@ module.exports.init = function (bs, opts, obs) {
          * @param coll
          * @returns {any}
          */
-        bs.optionUpdaters['proxy'] = function (incoming) {
-            return handleIncoming(Imm.fromJS(incoming));
+        bs.optionUpdaters['proxy'] = function (incoming, options) {
+            const imm = Imm.fromJS(incoming)
+            return options.set('proxy', handleIncoming(imm));
         }
     }
 };
@@ -252,12 +253,13 @@ var count = 0;
 
 function createOneProxyOption (item) {
 
-    return new ProxyOption()
-        .mergeDeep(item.mergeDeep({
-            id: `Browsersync Proxy (${count += 1})`,
-            url: Imm.Map(require('url').parse(item.get('target'))),
-            options: {
-                target: item.get('target')
-            }
-        }));
+    const incoming = Imm.fromJS({
+        id: `Browsersync Proxy (${count += 1})`,
+        url: Imm.Map(require('url').parse(item.get('target'))),
+        options: {
+            target: item.get('target')
+        }
+    });
+
+    return new ProxyOption().mergeDeep(incoming.mergeDeep(item));
 }

--- a/lib/rewrite-rules.ts
+++ b/lib/rewrite-rules.ts
@@ -1,8 +1,16 @@
-const Immutable    = require('immutable');
+import Immutable   = require('immutable');
 const mergeOpts    = require('./transform-options').mergeOptionsWithPlugins;
 const config       = require('./config');
+const OPT_NAME     = 'rewriteRules';
+let count          = 0;
 
-var count          = 0;
+export interface RewriteRule {
+    match: string|RegExp
+    fn?: (req:any, res:any, match:string) => string | string
+    replace?: (req:any, res:any, match:string) => string | string
+    via?: string
+    id?: string
+}
 
 /**
  * Pull server:middleware hooks from plugins
@@ -30,10 +38,6 @@ export function createOne (item) {
     }).mergeDeep(item);
 }
 
-/**
- *
- */
-export function fromJS (coll) {
-    return Immutable.fromJS(coll.map(createOne));
+export function fromJS(modified: RewriteRule[], options: Immutable.Map<string, any>) {
+    return options.set(OPT_NAME, Immutable.fromJS(modified.map(createOne)));
 }
-

--- a/test/mocha/api/setOption-clientJs.js
+++ b/test/mocha/api/setOption-clientJs.js
@@ -1,0 +1,40 @@
+const browserSync = require('../../../');
+const utils       = require('../utils');
+const request     = require('supertest');
+const assert      = require('chai').assert;
+
+describe('api: bs.setOption("clientJs")', function () {
+    it('can set client JS at run time (string)', function (done) {
+        browserSync.create({}).subscribe(function (bs) {
+            bs.setOption('clientJs', function (cjs) {
+                return cjs.concat('console.log("shane")');
+            }).subscribe(function (x) {
+                request(x.getIn(['urls', 'client-local']))
+                    .get('/')
+                    .set('Accept', 'text/html')
+                    .expect(200)
+                    .end(function (err, res) {
+                        assert.include(res.text, 'console.log("shane")');
+                        bs.cleanup(done);
+                    });
+            });
+        });
+    });
+    it('can set client JS at run time (obj)', function (done) {
+        browserSync.create({}).subscribe(function (bs) {
+            bs.setOption('clientJs', function (cjs) {
+                return cjs.concat({id: 'kittie', content: 'console.log("shane")'});
+            }).subscribe(function (x) {
+                request(x.getIn(['urls', 'client-local']))
+                    .get('/')
+                    .set('Accept', 'text/html')
+                    .expect(200)
+                    .end(function (err, res) {
+                        assert.include(res.text, 'ID:  kittie');
+                        assert.include(res.text, 'console.log("shane")');
+                        bs.cleanup(done);
+                    });
+            });
+        });
+    });
+});

--- a/test/mocha/api/setOption-middleware.js
+++ b/test/mocha/api/setOption-middleware.js
@@ -1,0 +1,67 @@
+const browserSync = require('../../../');
+const utils       = require('../utils');
+const request     = require('supertest');
+const assert      = require('chai').assert;
+
+describe('api: bs.setOption("middleware")', function () {
+    it('can set middleware at run time (single fn)', function (done) {
+        browserSync.create({}).subscribe(function (bs) {
+            bs.setOption('middleware', function (mw) {
+                return mw.concat(function (req, res) {
+                    res.end('shane');
+                });
+            }).subscribe(function (x) {
+                request(x.getIn(['urls', 'local']))
+                    .get('/')
+                    .set('Accept', 'text/html')
+                    .expect(200)
+                    .end(function (err, res) {
+                        assert.include(res.text, 'shane');
+                        bs.cleanup(done);
+                    });
+            });
+        });
+    });
+    it('can set middleware at run time (obj with ID)', function (done) {
+        browserSync.create({}).subscribe(function (bs) {
+            bs.setOption('middleware', function (mw) {
+                return mw.concat({id: "myMw", handle: function (req, res) {
+                    res.end('shane');
+                }});
+            }).subscribe(function (x) {
+                assert.equal(x.get('middleware').filter(x => x.get('id') === 'myMw').size, 1);
+                request(x.getIn(['urls', 'local']))
+                    .get('/')
+                    .set('Accept', 'text/html')
+                    .expect(200)
+                    .end(function (err, res) {
+                        assert.include(res.text, 'shane');
+                        bs.cleanup(done);
+                    });
+            });
+        });
+    });
+    it('can set middleware at run time (obj with route + ID)', function (done) {
+        browserSync.create({}).subscribe(function (bs) {
+            bs.setOption('middleware', function (mw) {
+                return mw.concat({
+                    id: 'myMw',
+                    route: '/shane',
+                    handle: function (req, res) {
+                        res.end('shane');
+                    }
+                });
+            }).subscribe(function (x) {
+                assert.equal(x.get('middleware').filter(x => x.get('id') === 'myMw').size, 1);
+                request(x.getIn(['urls', 'local']))
+                    .get('/shane')
+                    .set('Accept', 'text/html')
+                    .expect(200)
+                    .end(function (err, res) {
+                        assert.include(res.text, 'shane');
+                        bs.cleanup(done);
+                    });
+            });
+        });
+    });
+});

--- a/test/mocha/api/setOption-proxy.js
+++ b/test/mocha/api/setOption-proxy.js
@@ -1,0 +1,32 @@
+const browserSync = require('../../../');
+const utils       = require('../utils');
+const request     = require('supertest');
+const assert      = require('chai').assert;
+
+describe('api: bs.setOption("proxy")', function () {
+    it('can set the proxy dynamically at run time', function (done) {
+        const app = utils.getApp();
+        app.app.use(function (req, res) {
+            res.end(utils.resp1(app.url, ''));
+        });
+        browserSync.create({
+            proxy: 'shakyshane.com'
+        }).subscribe(function (bs) {
+            bs.setOption('proxy', function (proxies) {
+                return app.url;
+            }).subscribe(function (x) {
+                const bsPort = x.get('port');
+                assert.equal(x.getIn(['proxy', 0, 'target']), app.url);
+                request(x.getIn(['urls', 'local']))
+                    .get('/')
+                    .set('Accept', 'text/html')
+                    .expect(200)
+                    .end(function (err, res) {
+                        assert.equal(res.text, utils.resp1('//localhost:' + bsPort, x.get('snippet')));
+                        app.server.close();
+                        bs.cleanup(done);
+                    });
+            });
+        });
+    });
+});

--- a/test/mocha/api/setOption-rewriteRules.js
+++ b/test/mocha/api/setOption-rewriteRules.js
@@ -1,0 +1,30 @@
+const browserSync = require('../../../');
+const utils       = require('../utils');
+const request     = require('supertest');
+const assert      = require('chai').assert;
+
+describe('api: bs.setOption("rewriteRules")', function () {
+    it('can set rewrite rules at run time', function (done) {
+        browserSync.create({
+            middleware: [function (req, res) {
+                res.end('<!doctype html>\n<html lang="en-US">\n<head>\n    <meta charset="UTF-8">\n    <title></title>\n</head>\n<body>\n    <p>Shane</p>\n</body>\n</html>');
+            }]
+        }).subscribe(function (bs) {
+            bs.setOption('rewriteRules', function (rr) {
+                return rr.concat({
+                    match: 'Shane',
+                    replace: 'kittie'
+                });
+            }).subscribe(function (x) {
+                request(x.getIn(['urls', 'local']))
+                    .get('/')
+                    .set('Accept', 'text/html')
+                    .expect(200)
+                    .end(function (err, res) {
+                        assert.include(res.text, '<p>kittie</p>');
+                        bs.cleanup(done);
+                    });
+            });
+        });
+    });
+});

--- a/test/mocha/options/client-js.js
+++ b/test/mocha/options/client-js.js
@@ -43,7 +43,7 @@ describe('client js as options', function () {
         })
             .get('clientJs')
             .toJS()
-            .filter(function(x) { return x.via !== 'Browsersync core'});
+            .filter(function(x) { return x.via !== 'Browsersync Core'});
 
         // Plugin JS goes before any user-provided!
         assert.equal(input[0].content, client3);
@@ -90,7 +90,7 @@ describe('client js as options', function () {
     });
     it('has expected built-ins', function () {
         var items = process({}).get('clientJs').toJS();
-        assert.equal(items[0].via, 'Browsersync core');
+        assert.equal(items[0].via, 'Browsersync Core');
         assert.equal(items[0].id, 'bs-no-conflict');
         assert.equal(items[1].id, 'bs-socket-io');
         assert.equal(items[2].id, 'bs-socket-connector');

--- a/test/mocha/utils.js
+++ b/test/mocha/utils.js
@@ -32,6 +32,15 @@ utils.getClient = function (id, data) {
     };
 };
 
+utils.getApp = function () {
+    var app = connect();
+    var server = http.createServer(app);
+    server.listen();
+    var add = server.address();
+    var url = 'http://localhost:' + add.port;
+    return {app, url, server};
+};
+
 utils.proxye2e = function (resp, done) {
     var app = connect();
     var server = http.createServer(app);

--- a/test/mocha/utils.js
+++ b/test/mocha/utils.js
@@ -38,7 +38,7 @@ utils.proxye2e = function (resp, done) {
     server.listen();
     var add = server.address();
     var url = 'http://localhost:' + add.port;
-    var respIn = utils[resp](url);
+    var respIn = utils[resp](url, ''); // no snippet at this point
 
     app.use('/', function (req, res) {
         res.end(respIn);
@@ -61,7 +61,7 @@ utils.proxye2e = function (resp, done) {
                         return done(err);
                     });
                 }
-                assert.equal(res.text, utils[resp]('//localhost:' + bsPort) + snippet);
+                assert.equal(res.text, utils[resp]('//localhost:' + bsPort, snippet));
                 bs.cleanup(function () {
                     server.close();
                     done();
@@ -70,6 +70,6 @@ utils.proxye2e = function (resp, done) {
     });
 };
 
-utils.resp1 = function (host) {
-    return '<!doctype html><html lang="en"><head><meta charset="UTF-8"><title>Document</title><link rel="stylesheet" href="'+host+'/css/core.css"></head><body></body></html>';
+utils.resp1 = function (host, snippet) {
+    return '<!doctype html><html lang="en"><head><meta charset="UTF-8"><title>Document</title><link rel="stylesheet" href="'+host+'/css/core.css"></head><body>'+snippet+'</body></html>';
 };


### PR DESCRIPTION
This was a tricky one as the 'proxy' is one of the most complicated pieces within Browsersync.

Changing the the proxy not only affects the proxy option itself, but also requires modifications to middlewares & rewrite rules. 

This PR adds full support via the new API for setting/resetting & adding to the existing proxy option.

Use case: You are testing 1 URL on multiple devices/browsers and you want to switch to testing another site - this is now 100% possible without quitting the process. Via the API it will look something like...

```js
const bs = require('browser-sync');

bs.create({
    /**
     * Initial Proxy option when Browsersync starts
     */
    proxy: 'browsersync.io'
}).subscribe(bs => {

    /**
     * Later, if you need to change it, just update
     * the option and all of the ****magic**** will
     * be auto-applied for you. :)
     */
    bs.setOption('proxy', function (existing) {
        return 'bbc.co.uk';
    }).subscribe();
});

```

... but we'll also hook this into the UI so you'll be able to edit the proxy options via simple controls.

**Note**: This is also a big step forward to being able for us/anyone who wants to package Browsersync into an app.

re:
https://github.com/BrowserSync/UI/issues/6

